### PR TITLE
Add dynamic AI-powered chat suggestions above input bar

### DIFF
--- a/src/lib/ChatBox/BotMessage.svelte
+++ b/src/lib/ChatBox/BotMessage.svelte
@@ -1,23 +1,18 @@
 <script lang="ts">
 	import Huntbotlogo from '$lib/assets/huntbotlogo.svelte';
 	import { slide, fade } from 'svelte/transition';
-	import { chat } from './MessageStore';
 
 	export let value: string;
 	export let isLast: boolean = false;
+	export let onRetry: (() => void) | null = null;
 
 	$: updatedVal = value;
-
-	const { append } = chat();
 
 	let retried = false;
 
 	function handleRetry() {
 		retried = true;
-		append({
-			role: 'user',
-			content: "That response wasn't quite right — can you give a more specific or direct answer?"
-		});
+		onRetry?.();
 	}
 </script>
 

--- a/src/lib/ChatBox/BotMessage.svelte
+++ b/src/lib/ChatBox/BotMessage.svelte
@@ -1,15 +1,29 @@
 <script lang="ts">
 	import Huntbotlogo from '$lib/assets/huntbotlogo.svelte';
-	import { slide } from 'svelte/transition';
+	import { slide, fade } from 'svelte/transition';
+	import { chat } from './MessageStore';
 
 	export let value: string;
+	export let isLast: boolean = false;
 
 	$: updatedVal = value;
+
+	const { append } = chat();
+
+	let retried = false;
+
+	function handleRetry() {
+		retried = true;
+		append({
+			role: 'user',
+			content: "That response wasn't quite right — can you give a more specific or direct answer?"
+		});
+	}
 </script>
 
 <div
 	in:slide|global
-	class="flex w-[calc(full-4rem)] shrink-0 basis-12 flex-row flex-nowrap items-start gap-1 rounded px-1 text-stone-800 dark:text-stone-200"
+	class="group relative flex w-[calc(full-4rem)] shrink-0 basis-12 flex-row flex-nowrap items-start gap-1 rounded px-1 text-stone-800 dark:text-stone-200"
 >
 	<Huntbotlogo />
 
@@ -31,11 +45,34 @@
 			</svg>
 		</p>
 	{:else}
-		<p
-			class="mr-6 mt-3 grow whitespace-pre-line font-normal text-stone-600 dark:text-stone-400"
-			in:slide|global={{ duration: 400 }}
-		>
-			{@html value}
-		</p>
+		<div class="mr-6 mt-3 grow">
+			<p class="whitespace-pre-line font-normal text-stone-600 dark:text-stone-400" in:slide|global={{ duration: 400 }}>
+				{@html value}
+			</p>
+			{#if isLast && !retried}
+				<button
+					on:click={handleRetry}
+					title="This wasn't helpful"
+					transition:fade={{ duration: 150 }}
+					class="mt-1 flex items-center gap-1 text-xs text-stone-400 opacity-0 transition-opacity group-hover:opacity-100 hover:text-stone-600 dark:text-stone-600 dark:hover:text-stone-400"
+				>
+					<svg
+						xmlns="http://www.w3.org/2000/svg"
+						width="12"
+						height="12"
+						viewBox="0 0 24 24"
+						fill="none"
+						stroke="currentColor"
+						stroke-width="2"
+						stroke-linecap="round"
+						stroke-linejoin="round"
+					>
+						<path d="M10 15v4a3 3 0 0 0 3 3l4-9V2H5.72a2 2 0 0 0-2 1.7l-1.38 9a2 2 0 0 0 2 2.3z" />
+						<path d="M17 2h2.67A2.31 2.31 0 0 1 22 4v7a2.31 2.31 0 0 1-2.33 2H17" />
+					</svg>
+					Not helpful
+				</button>
+			{/if}
+		</div>
 	{/if}
 </div>

--- a/src/lib/ChatBox/ChatBox.svelte
+++ b/src/lib/ChatBox/ChatBox.svelte
@@ -112,6 +112,13 @@
 		// Server derives currentPage from the Referer header automatically
 		await append({ role: 'user', content: suggestion });
 	}
+
+	function retryLastResponse() {
+		append({
+			role: 'user',
+			content: "That response wasn't quite right — can you give a more specific or direct answer?"
+		});
+	}
 </script>
 
 <div
@@ -183,6 +190,7 @@
 							<BotMessage
 								value={message.content}
 								isLast={i === $messages.length - 1 && !$isLoading}
+								onRetry={retryLastResponse}
 							/>
 						{:else if message.role === 'function'}
 							<ActionMessage value={message} />

--- a/src/lib/ChatBox/ChatBox.svelte
+++ b/src/lib/ChatBox/ChatBox.svelte
@@ -11,7 +11,14 @@
 	import { page } from '$app/stores';
 	import Beaker from '$lib/assets/beaker.svelte';
 	import ActionMessage from './ActionMessage.svelte';
-	import { chat, botEngaged, minimized, suggestions, fetchSuggestions } from './MessageStore';
+	import {
+		chat,
+		botEngaged,
+		minimized,
+		suggestions,
+		fetchSuggestions,
+		triggerProactiveOpener
+	} from './MessageStore';
 	import LoadingStream from './LoadingStream.svelte';
 
 	const { messages, isLoading, handleSubmit, input, append } = chat();
@@ -76,6 +83,29 @@
 		suggestions.set([]);
 	}
 
+	// Proactive page-aware opener: fire when user navigates to a project/case study
+	// and hasn't started a conversation yet
+	let proactiveTimer: ReturnType<typeof setTimeout> | null = null;
+	let lastProactivePage = '';
+
+	$: {
+		const path = $page.url.pathname;
+		const isProjectPage = /^\/(case-studies|projects)\/.+/.test(path);
+		const hasUserMessages = $messages.some((m) => m.role === 'user');
+
+		if (isProjectPage && path !== lastProactivePage && !hasUserMessages && !$minimized) {
+			lastProactivePage = path;
+			if (proactiveTimer) clearTimeout(proactiveTimer);
+			proactiveTimer = setTimeout(() => {
+				triggerProactiveOpener($messages, path);
+			}, 2500);
+		} else if (!isProjectPage && lastProactivePage) {
+			// Reset when navigating away so it can fire again on the next project page
+			lastProactivePage = '';
+			if (proactiveTimer) clearTimeout(proactiveTimer);
+		}
+	}
+
 	async function selectSuggestion(suggestion: string) {
 		suggestions.set([]);
 		minimized.set(false);
@@ -137,7 +167,7 @@
 						with a grain of salt.
 					</p>
 				</div>
-				{#each $messages as message}
+				{#each $messages as message, i}
 					<div
 						in:slide|global={{ duration: 400 }}
 						on:introend={() => {
@@ -150,7 +180,10 @@
 						{#if message.role === 'user'}
 							<UserMessage value={message.content} />
 						{:else if message.role === 'assistant'}
-							<BotMessage value={message.content} />
+							<BotMessage
+								value={message.content}
+								isLast={i === $messages.length - 1 && !$isLoading}
+							/>
 						{:else if message.role === 'function'}
 							<ActionMessage value={message} />
 						{/if}

--- a/src/lib/ChatBox/ChatBox.svelte
+++ b/src/lib/ChatBox/ChatBox.svelte
@@ -61,21 +61,17 @@
 		minimized.set(true);
 	}
 
-	// Track loading transitions to fetch suggestions after each bot response
+	// Track loading transitions to fetch suggestions after each bot response,
+	// but only once a real conversation is underway (user has sent at least one message)
 	let prevLoading = false;
 	$: {
 		if (prevLoading && !$isLoading) {
-			fetchSuggestions($messages, $page.url.pathname);
+			const hasUserMessages = $messages.some((m) => m.role === 'user');
+			if (hasUserMessages) {
+				fetchSuggestions($messages, $page.url.pathname);
+			}
 		}
 		prevLoading = $isLoading ?? false;
-	}
-
-	// Fetch starter suggestions when chat opens with no user messages yet
-	$: if ($botEngaged && !$minimized && !$isLoading) {
-		const hasUserMessages = $messages.some((m) => m.role === 'user');
-		if (!hasUserMessages && $suggestions.length === 0) {
-			fetchSuggestions($messages, $page.url.pathname);
-		}
 	}
 
 	// Clear suggestions when user starts typing

--- a/src/lib/ChatBox/ChatBox.svelte
+++ b/src/lib/ChatBox/ChatBox.svelte
@@ -74,6 +74,15 @@
 		prevLoading = $isLoading ?? false;
 	}
 
+	// Show starter suggestions once the intro message is visible and no conversation yet
+	$: if ($botEngaged && !$minimized && !$isLoading) {
+		const hasUserMessages = $messages.some((m) => m.role === 'user');
+		const hasBotMessages = $messages.some((m) => m.role === 'assistant');
+		if (!hasUserMessages && hasBotMessages && $suggestions.length === 0) {
+			fetchSuggestions($messages, $page.url.pathname);
+		}
+	}
+
 	// Clear suggestions when user starts typing
 	$: if ($input && $input.trim() !== '') {
 		suggestions.set([]);

--- a/src/lib/ChatBox/ChatBox.svelte
+++ b/src/lib/ChatBox/ChatBox.svelte
@@ -3,6 +3,7 @@
 	import UserMessage from './UserMessage.svelte';
 	import BotMessage from './BotMessage.svelte';
 	import GreetingMessage from './GreetingMessage.svelte';
+	import ChatSuggestions from './ChatSuggestions.svelte';
 	import { slide, fade } from 'svelte/transition';
 	import { cubicOut } from 'svelte/easing';
 	import arrowdown from '$lib/assets/arrow-down.svg';
@@ -10,10 +11,10 @@
 	import { page } from '$app/stores';
 	import Beaker from '$lib/assets/beaker.svelte';
 	import ActionMessage from './ActionMessage.svelte';
-	import { chat, botEngaged, minimized } from './MessageStore';
+	import { chat, botEngaged, minimized, suggestions, fetchSuggestions } from './MessageStore';
 	import LoadingStream from './LoadingStream.svelte';
 
-	const { messages, isLoading, handleSubmit, input } = chat();
+	const { messages, isLoading, handleSubmit, input, append } = chat();
 
 	let scrollElement: HTMLDivElement;
 	let isScrolling = false;
@@ -51,6 +52,35 @@
 
 	$: if (!$navEngaged) {
 		minimized.set(true);
+	}
+
+	// Track loading transitions to fetch suggestions after each bot response
+	let prevLoading = false;
+	$: {
+		if (prevLoading && !$isLoading) {
+			fetchSuggestions($messages, $page.url.pathname);
+		}
+		prevLoading = $isLoading ?? false;
+	}
+
+	// Fetch starter suggestions when chat opens with no user messages yet
+	$: if ($botEngaged && !$minimized && !$isLoading) {
+		const hasUserMessages = $messages.some((m) => m.role === 'user');
+		if (!hasUserMessages && $suggestions.length === 0) {
+			fetchSuggestions($messages, $page.url.pathname);
+		}
+	}
+
+	// Clear suggestions when user starts typing
+	$: if ($input && $input.trim() !== '') {
+		suggestions.set([]);
+	}
+
+	async function selectSuggestion(suggestion: string) {
+		suggestions.set([]);
+		minimized.set(false);
+		// Server derives currentPage from the Referer header automatically
+		await append({ role: 'user', content: suggestion });
 	}
 </script>
 
@@ -141,6 +171,9 @@
 				{/if}
 			</div>
 		</div>
+	{/if}
+	{#if $botEngaged && !$minimized && !$isLoading && $input.trim() === ''}
+		<ChatSuggestions suggestions={$suggestions} onSelect={selectSuggestion} />
 	{/if}
 	{#if $botEngaged}
 		<TextInput {isLoading} {handleSubmit} {input} currentPage={$page.url.pathname} />

--- a/src/lib/ChatBox/ChatBox.svelte
+++ b/src/lib/ChatBox/ChatBox.svelte
@@ -27,7 +27,7 @@
 	let isScrolling = false;
 	let scrolledToBottom = false;
 
-	export let greeting: string = "Hi 👋, I'm HuntBot";
+	export let greeting: string = "Hi, I'm HuntBot";
 
 	// Check if scrolled to the bottom
 	function checkScrolledDown() {

--- a/src/lib/ChatBox/ChatSuggestions.svelte
+++ b/src/lib/ChatBox/ChatSuggestions.svelte
@@ -7,13 +7,13 @@
 
 {#if suggestions.length > 0}
 	<div
-		class="no-scrollbar flex min-h-[44px] items-center gap-1.5 overflow-x-auto overflow-y-hidden px-2 py-2"
+		class="no-scrollbar flex min-h-[44px] items-center gap-1.5 overflow-x-auto overflow-y-hidden px-2 py-8"
 		transition:fade|global={{ duration: 150 }}
 	>
 		{#each suggestions as suggestion (suggestion)}
 			<button
 				on:click={() => onSelect(suggestion)}
-				class="flex h-10 shrink-0 items-center whitespace-nowrap rounded-full border border-stone-300 px-3.5 text-xs text-stone-600 transition hover:border-stone-400 hover:bg-stone-100 active:bg-stone-200 dark:border-stone-700 dark:text-stone-400 dark:hover:border-stone-600 dark:hover:bg-stone-900 dark:active:bg-stone-800"
+				class="flex h-10 shrink-0 items-center whitespace-nowrap rounded-full border border-slate-200 px-3.5 text-xs text-stone-600 transition hover:border-slate-300 hover:bg-stone-100 active:bg-stone-200 dark:border-slate-800 dark:text-stone-400 dark:hover:border-slate-700 dark:hover:bg-stone-900 dark:active:bg-stone-800"
 			>
 				{suggestion}
 			</button>

--- a/src/lib/ChatBox/ChatSuggestions.svelte
+++ b/src/lib/ChatBox/ChatSuggestions.svelte
@@ -7,13 +7,13 @@
 
 {#if suggestions.length > 0}
 	<div
-		class="no-scrollbar flex gap-2 overflow-x-auto px-2 pb-2 pt-1"
+		class="no-scrollbar flex min-h-[44px] items-center gap-[2px] overflow-x-auto overflow-y-hidden px-2"
 		transition:fade|global={{ duration: 150 }}
 	>
 		{#each suggestions as suggestion (suggestion)}
 			<button
 				on:click={() => onSelect(suggestion)}
-				class="shrink-0 rounded-full border border-stone-300 bg-stone-50 px-3 py-1.5 text-xs text-stone-600 transition hover:border-stone-400 hover:bg-stone-100 active:bg-stone-200 dark:border-stone-700 dark:bg-stone-900 dark:text-stone-400 dark:hover:border-stone-600 dark:hover:bg-stone-800 dark:active:bg-stone-700"
+				class="shrink-0 rounded bg-stone-200 p-1 pb-[2px] text-xs uppercase tracking-wider text-stone-900 transition hover:bg-stone-300 active:bg-stone-400 dark:bg-stone-800 dark:text-stone-100 dark:hover:bg-stone-700 dark:active:bg-stone-600"
 			>
 				{suggestion}
 			</button>

--- a/src/lib/ChatBox/ChatSuggestions.svelte
+++ b/src/lib/ChatBox/ChatSuggestions.svelte
@@ -1,0 +1,32 @@
+<script lang="ts">
+	import { fade } from 'svelte/transition';
+
+	export let suggestions: string[] = [];
+	export let onSelect: (suggestion: string) => void;
+</script>
+
+{#if suggestions.length > 0}
+	<div
+		class="no-scrollbar flex gap-2 overflow-x-auto px-2 pb-2 pt-1"
+		transition:fade|global={{ duration: 150 }}
+	>
+		{#each suggestions as suggestion (suggestion)}
+			<button
+				on:click={() => onSelect(suggestion)}
+				class="shrink-0 rounded-full border border-stone-300 bg-stone-50 px-3 py-1.5 text-xs text-stone-600 transition hover:border-stone-400 hover:bg-stone-100 active:bg-stone-200 dark:border-stone-700 dark:bg-stone-900 dark:text-stone-400 dark:hover:border-stone-600 dark:hover:bg-stone-800 dark:active:bg-stone-700"
+			>
+				{suggestion}
+			</button>
+		{/each}
+	</div>
+{/if}
+
+<style>
+	.no-scrollbar::-webkit-scrollbar {
+		display: none;
+	}
+	.no-scrollbar {
+		-ms-overflow-style: none;
+		scrollbar-width: none;
+	}
+</style>

--- a/src/lib/ChatBox/ChatSuggestions.svelte
+++ b/src/lib/ChatBox/ChatSuggestions.svelte
@@ -13,7 +13,7 @@
 		{#each suggestions as suggestion (suggestion)}
 			<button
 				on:click={() => onSelect(suggestion)}
-				class="shrink-0 whitespace-nowrap rounded-full border border-stone-300 px-3 py-1 text-xs text-stone-600 transition hover:border-stone-400 hover:bg-stone-100 active:bg-stone-200 dark:border-stone-700 dark:text-stone-400 dark:hover:border-stone-600 dark:hover:bg-stone-900 dark:active:bg-stone-800"
+				class="flex h-10 shrink-0 items-center whitespace-nowrap rounded-full border border-stone-300 px-3.5 text-xs text-stone-600 transition hover:border-stone-400 hover:bg-stone-100 active:bg-stone-200 dark:border-stone-700 dark:text-stone-400 dark:hover:border-stone-600 dark:hover:bg-stone-900 dark:active:bg-stone-800"
 			>
 				{suggestion}
 			</button>

--- a/src/lib/ChatBox/ChatSuggestions.svelte
+++ b/src/lib/ChatBox/ChatSuggestions.svelte
@@ -7,7 +7,7 @@
 
 {#if suggestions.length > 0}
 	<div
-		class="no-scrollbar flex min-h-[44px] items-center gap-1.5 overflow-x-auto overflow-y-hidden px-2 pb-2"
+		class="no-scrollbar flex min-h-[44px] items-center gap-1.5 overflow-x-auto overflow-y-hidden px-2 py-2"
 		transition:fade|global={{ duration: 150 }}
 	>
 		{#each suggestions as suggestion (suggestion)}

--- a/src/lib/ChatBox/ChatSuggestions.svelte
+++ b/src/lib/ChatBox/ChatSuggestions.svelte
@@ -7,7 +7,7 @@
 
 {#if suggestions.length > 0}
 	<div
-		class="no-scrollbar flex min-h-[44px] items-center gap-1.5 overflow-x-auto overflow-y-hidden px-2"
+		class="no-scrollbar flex min-h-[44px] items-center gap-1.5 overflow-x-auto overflow-y-hidden px-2 pb-2"
 		transition:fade|global={{ duration: 150 }}
 	>
 		{#each suggestions as suggestion (suggestion)}

--- a/src/lib/ChatBox/ChatSuggestions.svelte
+++ b/src/lib/ChatBox/ChatSuggestions.svelte
@@ -7,7 +7,7 @@
 
 {#if suggestions.length > 0}
 	<div
-		class="no-scrollbar flex min-h-[44px] items-center gap-1.5 overflow-x-auto overflow-y-hidden px-2 py-8"
+		class="no-scrollbar flex min-h-[44px] items-center gap-1.5 overflow-x-auto overflow-y-hidden px-2 pb-8 pt-2"
 		transition:fade|global={{ duration: 150 }}
 	>
 		{#each suggestions as suggestion (suggestion)}

--- a/src/lib/ChatBox/ChatSuggestions.svelte
+++ b/src/lib/ChatBox/ChatSuggestions.svelte
@@ -7,13 +7,13 @@
 
 {#if suggestions.length > 0}
 	<div
-		class="no-scrollbar flex min-h-[44px] items-center gap-[2px] overflow-x-auto overflow-y-hidden px-2"
+		class="no-scrollbar flex min-h-[44px] items-center gap-1.5 overflow-x-auto overflow-y-hidden px-2"
 		transition:fade|global={{ duration: 150 }}
 	>
 		{#each suggestions as suggestion (suggestion)}
 			<button
 				on:click={() => onSelect(suggestion)}
-				class="shrink-0 rounded bg-stone-200 p-1 pb-[2px] text-xs uppercase tracking-wider text-stone-900 transition hover:bg-stone-300 active:bg-stone-400 dark:bg-stone-800 dark:text-stone-100 dark:hover:bg-stone-700 dark:active:bg-stone-600"
+				class="shrink-0 whitespace-nowrap rounded-full border border-stone-300 px-3 py-1 text-xs text-stone-600 transition hover:border-stone-400 hover:bg-stone-100 active:bg-stone-200 dark:border-stone-700 dark:text-stone-400 dark:hover:border-stone-600 dark:hover:bg-stone-900 dark:active:bg-stone-800"
 			>
 				{suggestion}
 			</button>

--- a/src/lib/ChatBox/LoadingStream.svelte
+++ b/src/lib/ChatBox/LoadingStream.svelte
@@ -9,20 +9,46 @@
 >
 	<Huntbotlogo />
 
-	<p class="mr-6 mt-3 grow whitespace-pre-line">
-		<svg
-			class="inline-block h-5 w-5 animate-spin text-slate-400"
-			xmlns="http://www.w3.org/2000/svg"
-			fill="none"
-			viewBox="0 0 24 24"
-		>
-			<circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"
-			></circle>
-			<path
-				class="opacity-75"
-				fill="currentColor"
-				d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
-			></path>
-		</svg>
+	<p class="mr-6 mt-3.5 grow whitespace-pre-line">
+		<span class="dots" aria-label="HuntBot is thinking">
+			<span class="dot" />
+			<span class="dot" />
+			<span class="dot" />
+		</span>
 	</p>
 </div>
+
+<style>
+	.dots {
+		display: inline-flex;
+		align-items: center;
+		gap: 4px;
+	}
+	.dot {
+		display: inline-block;
+		width: 6px;
+		height: 6px;
+		border-radius: 50%;
+		background: currentColor;
+		opacity: 0.5;
+		animation: huntbot-bounce 1.2s ease-in-out infinite;
+	}
+	.dot:nth-child(2) {
+		animation-delay: 0.2s;
+	}
+	.dot:nth-child(3) {
+		animation-delay: 0.4s;
+	}
+	@keyframes huntbot-bounce {
+		0%,
+		60%,
+		100% {
+			transform: translateY(0);
+			opacity: 0.5;
+		}
+		30% {
+			transform: translateY(-5px);
+			opacity: 1;
+		}
+	}
+</style>

--- a/src/lib/ChatBox/MessageStore.ts
+++ b/src/lib/ChatBox/MessageStore.ts
@@ -128,10 +128,6 @@ const functionCallHandler: FunctionCallHandler = async (chatMessages, functionCa
 			setTimeout(() => {
 				goto(`${parsedFunctionCallArguments.page}`);
 			}, 400);
-
-			// Return the same messages so the SDK makes a follow-up LLM call,
-			// allowing the bot to say something after navigating.
-			return { messages: updatedMessages };
 		}
 	} else if (functionCall.name === 'ask_clarifying_question') {
 		if (functionCall.arguments) {

--- a/src/lib/ChatBox/MessageStore.ts
+++ b/src/lib/ChatBox/MessageStore.ts
@@ -7,6 +7,34 @@ import { writable } from 'svelte/store';
 
 export const suggestions = writable<string[]>([]);
 
+export async function triggerProactiveOpener(
+	currentMessages: Message[],
+	currentPage: string
+): Promise<void> {
+	try {
+		const response = await fetch('/api/chat/proactive', {
+			method: 'POST',
+			headers: { 'Content-Type': 'application/json' },
+			body: JSON.stringify({ currentPage })
+		});
+		if (response.ok) {
+			const data = await response.json();
+			if (data.message && setMessagesGlobal) {
+				setMessagesGlobal([
+					...currentMessages,
+					{
+						id: 'proactive-' + Date.now(),
+						role: 'assistant' as const,
+						content: data.message
+					}
+				]);
+			}
+		}
+	} catch {
+		// Silently fail — proactive opener is best-effort
+	}
+}
+
 export async function fetchSuggestions(messages: Message[], currentPage: string): Promise<void> {
 	try {
 		const response = await fetch('/api/chat/suggestions', {

--- a/src/lib/ChatBox/MessageStore.ts
+++ b/src/lib/ChatBox/MessageStore.ts
@@ -5,6 +5,24 @@ import { nanoid } from 'ai';
 import { useChat, type Message } from 'ai/svelte';
 import { writable } from 'svelte/store';
 
+export const suggestions = writable<string[]>([]);
+
+export async function fetchSuggestions(messages: Message[], currentPage: string): Promise<void> {
+	try {
+		const response = await fetch('/api/chat/suggestions', {
+			method: 'POST',
+			headers: { 'Content-Type': 'application/json' },
+			body: JSON.stringify({ messages, currentPage })
+		});
+		if (response.ok) {
+			const data = await response.json();
+			suggestions.set(data.suggestions ?? []);
+		}
+	} catch {
+		suggestions.set([]);
+	}
+}
+
 const greetingResponse: string =
 	"I know, I know, another chatbot. Hear me out, I'm a Frankenstein project Hunter hacked together to pitch himself. I'm wired into his site.\nIf you're game, ask me a question. You could ask about his work, design philosophy, or about life.\nIf you don't want to play along, you can minimize me up to your right↗";
 

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -44,7 +44,7 @@
 		const scrollDistance = mobileBreakpoint ? window.innerHeight / 2 : window.innerHeight / 2 - 64;
 		if (!$botEngaged) {
 			hitButton = true;
-			greeting = "Hi 👋, I'm HuntBot";
+			greeting = "Hi, I'm HuntBot";
 		} else {
 			minimized.set(false);
 		}

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -59,7 +59,7 @@
 					bind:this={element}
 				>
 					Let's build the product your users <span class="font-serif italic">actually</span>
-					want 🎯
+					want
 					<!-- I’m the designer that will build you a product your users really want. -->
 				</h1>
 			</div>

--- a/src/routes/api/chat/+server.ts
+++ b/src/routes/api/chat/+server.ts
@@ -171,7 +171,10 @@ Today is ${today}. Use this to interpret relative time questions like "recently"
 
 ## Current page
 The visitor is currently on: ${currentPage}
-If this is a specific case study or project URL (e.g. /case-studies/karoo2), they are already looking at that work — engage with it directly, don't ask them what they want to know about it. If they're on the home page, /case-studies, or /projects, treat them as still browsing.
+If this is a specific case study or project URL (e.g. /case-studies/karoo2), they are already looking at that work — engage with it directly. Lead with the most interesting design decision or challenge from context — don't ask what aspect they want to know about. If they're on the home page, /case-studies, or /projects, treat them as still browsing.
+
+## Handling knowledge gaps
+When the CONTEXT section doesn't contain enough to answer specifically: acknowledge it briefly in one clause ("I don't have details on that specifically..."), then immediately pivot to the most relevant thing you do know. End with something actionable — offer to route them somewhere, name a related topic, or ask one focused question. Never end a response with just "I don't know" or a bare apology.
 
 ## Tools
 - Use ask_clarifying_question sparingly — only when you genuinely cannot give a useful answer without more info. If you have relevant context, share it. Never ask a clarifying question when the visitor is already on a specific project or case study page. Don't ask clarifying questions back-to-back.

--- a/src/routes/api/chat/proactive/+server.ts
+++ b/src/routes/api/chat/proactive/+server.ts
@@ -1,0 +1,55 @@
+import { env } from '$env/dynamic/private';
+import { compile } from 'html-to-text';
+import { json, type RequestHandler } from '@sveltejs/kit';
+import OpenAI from 'openai';
+
+const openai = new OpenAI({ apiKey: env.OPENAI_API_KEY });
+const convertHtml = compile({ wordwrap: 130 });
+const SITE_ORIGIN = 'https://www.hunterbryant.io';
+
+async function fetchPageText(path: string): Promise<string | null> {
+	try {
+		const res = await fetch(`${SITE_ORIGIN}${path}`, { signal: AbortSignal.timeout(5000) });
+		if (!res.ok) return null;
+		const html = await res.text();
+		return convertHtml(html).slice(0, 6000);
+	} catch {
+		return null;
+	}
+}
+
+export const POST: RequestHandler = async ({ request }) => {
+	try {
+		const { currentPage } = await request.json();
+
+		// Only fire on specific project/case study pages
+		if (!currentPage || !currentPage.match(/^\/(case-studies|projects)\/.+/)) {
+			return json({ message: null });
+		}
+
+		const pageText = await fetchPageText(currentPage);
+		if (!pageText) {
+			return json({ message: null });
+		}
+
+		const response = await openai.chat.completions.create({
+			model: 'gpt-4.1-mini',
+			messages: [
+				{
+					role: 'system',
+					content: `You are HuntBot, an assistant on Hunter Bryant's portfolio. A visitor just arrived on a specific project or case study page. Write a single natural sentence (max 20 words) that mentions something specific and interesting from this page — a hook that makes them want to ask more. Conversational, not promotional. No emojis. Examples: "This project had a pretty unusual constraint — want me to walk you through it?" or "The sensor calibration work on this one was surprisingly deep."
+
+Page content:
+${pageText}`
+				}
+			],
+			max_tokens: 60,
+			temperature: 0.8
+		});
+
+		const message = response.choices[0]?.message?.content?.trim() ?? null;
+		return json({ message });
+	} catch {
+		return json({ message: null });
+	}
+};

--- a/src/routes/api/chat/suggestions/+server.ts
+++ b/src/routes/api/chat/suggestions/+server.ts
@@ -1,0 +1,77 @@
+import { env } from '$env/dynamic/private';
+import { json, type RequestHandler } from '@sveltejs/kit';
+import OpenAI from 'openai';
+
+const openai = new OpenAI({ apiKey: env.OPENAI_API_KEY });
+
+export const POST: RequestHandler = async ({ request }) => {
+	try {
+		const { messages, currentPage } = await request.json();
+
+		const hasUserMessages = messages.some((m: { role: string }) => m.role === 'user');
+
+		const systemPrompt = hasUserMessages
+			? `Generate 3–4 short follow-up question suggestions (under 8 words each) for a visitor chatting with HuntBot on Hunter Bryant's portfolio site.
+
+Current page: ${currentPage}
+
+Rules:
+- Make them natural and specific to the conversation context
+- No generic filler — each suggestion should feel useful
+- Return ONLY a JSON array of strings, nothing else
+
+Example: ["What was the biggest design challenge?", "Can I see the final product?"]`
+			: `Generate 3–4 short starter question suggestions (under 8 words each) for a new visitor on Hunter Bryant's portfolio site.
+
+Current page: ${currentPage}
+
+Hunter is a senior product designer known for hardware/software products, cycling tech, and consumer apps.
+
+Rules:
+- Tailor to the current page context if not the home page
+- Make them feel like genuine curiosity, not marketing prompts
+- Return ONLY a JSON array of strings, nothing else
+
+Example: ["What kind of projects does Hunter take on?", "Tell me about his design process"]`;
+
+		const conversationContext = hasUserMessages
+			? messages
+					.filter((m: { role: string }) => m.role !== 'function')
+					.slice(-6)
+					.map((m: { role: string; content: string }) => `${m.role}: ${m.content}`)
+					.join('\n')
+			: null;
+
+		const response = await openai.chat.completions.create({
+			model: 'gpt-4.1-mini',
+			messages: [
+				{ role: 'system', content: systemPrompt },
+				...(conversationContext
+					? [{ role: 'user' as const, content: conversationContext }]
+					: [])
+			],
+			temperature: 0.7,
+			max_tokens: 150
+		});
+
+		const raw = response.choices[0]?.message?.content ?? '[]';
+
+		let suggestions: string[] = [];
+		try {
+			const match = raw.match(/\[[\s\S]*\]/);
+			if (match) {
+				suggestions = JSON.parse(match[0]);
+			}
+		} catch {
+			suggestions = [];
+		}
+
+		suggestions = suggestions
+			.filter((s): s is string => typeof s === 'string' && s.trim().length > 0)
+			.slice(0, 4);
+
+		return json({ suggestions });
+	} catch {
+		return json({ suggestions: [] });
+	}
+};

--- a/src/routes/api/chat/suggestions/+server.ts
+++ b/src/routes/api/chat/suggestions/+server.ts
@@ -11,7 +11,7 @@ export const POST: RequestHandler = async ({ request }) => {
 		const hasUserMessages = messages.some((m: { role: string }) => m.role === 'user');
 
 		const systemPrompt = hasUserMessages
-			? `Generate 3–4 short follow-up question suggestions (under 8 words each) for a visitor chatting with HuntBot on Hunter Bryant's portfolio site.
+			? `Generate 3 short follow-up question suggestions (under 8 words each) for a visitor chatting with HuntBot on Hunter Bryant's portfolio site.
 
 Current page: ${currentPage}
 
@@ -21,7 +21,7 @@ Rules:
 - Return ONLY a JSON array of strings, nothing else
 
 Example: ["What was the biggest design challenge?", "Can I see the final product?"]`
-			: `Generate 3–4 short starter question suggestions (under 8 words each) for a new visitor on Hunter Bryant's portfolio site.
+			: `Generate 3 short starter question suggestions (under 8 words each) for a new visitor on Hunter Bryant's portfolio site.
 
 Current page: ${currentPage}
 
@@ -68,7 +68,7 @@ Example: ["What kind of projects does Hunter take on?", "Tell me about his desig
 
 		suggestions = suggestions
 			.filter((s): s is string => typeof s === 'string' && s.trim().length > 0)
-			.slice(0, 4);
+			.slice(0, 3);
 
 		return json({ suggestions });
 	} catch {


### PR DESCRIPTION
Adds a horizontal scrollable row of contextual suggestions that appear above
the text input when helpful — on zero-state open, after each bot response, and
at dead ends. Suggestions are generated by gpt-4.1-mini via a new
/api/chat/suggestions endpoint, tailored to the current page and conversation
context. Suggestions hide while the bot is loading or when the user types.

https://claude.ai/code/session_01Jt7TrnhJVT7NfBiPWCMboU