### PR TITLE
Add current status easter egg on landing page with admin controls

### DIFF
--- a/src/lib/server/status-config.ts
+++ b/src/lib/server/status-config.ts
@@ -1,0 +1,71 @@
+import { env } from '$env/dynamic/private';
+import { getPointVectorForUpsert, getQdrantClient } from '$lib/server/qdrant-search';
+
+const CONFIG_POINT_ID = 'b0000000-0000-0000-0000-000000000002';
+const VECTOR_DIMS = 512;
+const CACHE_TTL_MS = 60_000;
+
+interface StatusData {
+	text: string;
+	updatedAt: string;
+}
+
+let cached: StatusData | null = null;
+let cacheTime = 0;
+
+export async function getStatus(): Promise<StatusData | null> {
+	if (cached !== null && Date.now() - cacheTime < CACHE_TTL_MS) {
+		return cached;
+	}
+
+	try {
+		const client = getQdrantClient();
+		const result = await client.retrieve(env.QDRANT_COLLECTION!, {
+			ids: [CONFIG_POINT_ID],
+			with_payload: true,
+			with_vector: false
+		});
+
+		const payload = result?.[0]?.payload;
+		if (!payload?.statusText || typeof payload.statusText !== 'string') {
+			cached = null;
+			cacheTime = Date.now();
+			return null;
+		}
+
+		const data: StatusData = {
+			text: payload.statusText as string,
+			updatedAt: (payload.updatedAt as string) || new Date().toISOString()
+		};
+		cached = data;
+		cacheTime = Date.now();
+		return data;
+	} catch {
+		return cached ?? null;
+	}
+}
+
+export async function setStatus(text: string): Promise<void> {
+	const client = getQdrantClient();
+	const collection = env.QDRANT_COLLECTION!;
+	const zeroVec = new Array(VECTOR_DIMS).fill(0);
+	const vector = await getPointVectorForUpsert(client, collection, zeroVec);
+	const updatedAt = new Date().toISOString();
+
+	await client.upsert(collection, {
+		points: [
+			{
+				id: CONFIG_POINT_ID,
+				vector,
+				payload: { type: '_config', statusText: text, updatedAt }
+			}
+		]
+	});
+
+	if (text) {
+		cached = { text, updatedAt };
+	} else {
+		cached = null;
+	}
+	cacheTime = Date.now();
+}

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -6,6 +6,7 @@
 	import { components } from '$lib/slices';
 	import { onMount } from 'svelte';
 	import { beforeNavigate } from '$app/navigation';
+	import { fade } from 'svelte/transition';
 	import HeroPixelHeadline from '$lib/landing/HeroPixelHeadline.svelte';
 
 	export let data;
@@ -14,6 +15,8 @@
 	let mobileElement: HTMLElement;
 	let onScreen = true;
 	let debounced = false;
+	let statusText: string | null = null;
+	let showStatus = false;
 
 	// Logic to start scroll onberver
 	$: if (debounced && typeof onScreen !== 'undefined') {
@@ -25,6 +28,20 @@
 		setTimeout(() => {
 			debounced = true;
 		}, 500);
+
+		// Fetch current status for easter egg
+		fetch('/api/status')
+			.then((r) => r.json())
+			.then((d) => {
+				if (d.text) {
+					statusText = d.text;
+					// Delay reveal for a subtle discovery feel
+					setTimeout(() => {
+						showStatus = true;
+					}, 1500);
+				}
+			})
+			.catch(() => {});
 	});
 
 	// Similar to the above problem, avoid multiple scroll events when DOM is deconstructed
@@ -54,7 +71,15 @@
 			class="relative grid h-[calc(50svh-3rem)] grow grid-cols-5 grid-rows-1 gap-4 pt-4 sm:h-[calc(calc(50svh-64px)-0.5rem)] md:grid-cols-7 lg:grid-cols-9"
 		>
 			<!-- Todo: animate title right after scroll -->
-			<div class="col-span-5 col-start-1 row-span-1 row-start-1 flex sm:col-span-4 lg:col-span-5">
+			<div class="col-span-5 col-start-1 row-span-1 row-start-1 flex flex-col sm:col-span-4 lg:col-span-5">
+				{#if showStatus && statusText}
+					<p
+						transition:fade={{ duration: 600 }}
+						class="absolute -top-[4.35rem] text-xs font-medium uppercase tracking-wider text-stone-400 sm:relative sm:top-0 sm:mb-2 dark:text-stone-500"
+					>
+						{statusText}
+					</p>
+				{/if}
 				<h1
 					class="absolute -top-[3.09rem] my-auto min-w-0 max-w-full text-5xl font-medium tracking-tighter text-stone-900 sm:relative sm:top-0 sm:z-40 xl:text-5xl dark:text-stone-100 dark:mix-blend-exclusion"
 					bind:this={element}

--- a/src/routes/admin/+page.svelte
+++ b/src/routes/admin/+page.svelte
@@ -1,4 +1,71 @@
 <script lang="ts">
+	import { onMount } from 'svelte';
+
+	let currentStatus: string | null = null;
+	let inputText = '';
+	let suggestions: string[] = [];
+	let saving = false;
+	let suggesting = false;
+
+	onMount(async () => {
+		try {
+			const res = await fetch('/api/admin/status');
+			const data = await res.json();
+			currentStatus = data.text || null;
+		} catch {
+			// leave default
+		}
+	});
+
+	async function saveStatus() {
+		saving = true;
+		try {
+			const res = await fetch('/api/admin/status', {
+				method: 'POST',
+				headers: { 'Content-Type': 'application/json' },
+				body: JSON.stringify({ text: inputText })
+			});
+			const data = await res.json();
+			currentStatus = data.text || null;
+			inputText = '';
+			suggestions = [];
+		} finally {
+			saving = false;
+		}
+	}
+
+	async function clearStatus() {
+		saving = true;
+		try {
+			const res = await fetch('/api/admin/status', {
+				method: 'POST',
+				headers: { 'Content-Type': 'application/json' },
+				body: JSON.stringify({ text: '' })
+			});
+			const data = await res.json();
+			currentStatus = data.text || null;
+			inputText = '';
+			suggestions = [];
+		} finally {
+			saving = false;
+		}
+	}
+
+	async function suggest() {
+		if (!inputText.trim()) return;
+		suggesting = true;
+		try {
+			const res = await fetch('/api/admin/status/suggest', {
+				method: 'POST',
+				headers: { 'Content-Type': 'application/json' },
+				body: JSON.stringify({ input: inputText })
+			});
+			const data = await res.json();
+			suggestions = data.suggestions || [];
+		} finally {
+			suggesting = false;
+		}
+	}
 </script>
 
 <svelte:head>
@@ -19,6 +86,71 @@
 			>
 				Admin
 			</h2>
+		</div>
+
+		<!-- Status Easter Egg -->
+		<div
+			class="col-start-1 col-end-6 mb-6 flex flex-col gap-3 sm:col-start-4 sm:col-end-7 md:col-end-8 lg:col-end-10"
+		>
+			<p class="text-xs font-medium uppercase tracking-wider text-stone-400 dark:text-stone-500">
+				Status
+			</p>
+
+			{#if currentStatus}
+				<p class="text-sm text-stone-600 dark:text-stone-400">
+					Current: <span class="font-medium">{currentStatus}</span>
+				</p>
+			{:else}
+				<p class="text-sm text-stone-400 dark:text-stone-500">No status set</p>
+			{/if}
+
+			<div class="flex gap-2">
+				<input
+					type="text"
+					bind:value={inputText}
+					placeholder="e.g. eating birria in mexico city"
+					class="flex-1 rounded border border-stone-200 bg-transparent px-3 py-2 text-sm text-stone-800 placeholder-stone-400 outline-none transition-colors focus:border-stone-400 dark:border-stone-800 dark:text-stone-200 dark:placeholder-stone-600 dark:focus:border-stone-600"
+				/>
+				<button
+					on:click={suggest}
+					disabled={suggesting || !inputText.trim()}
+					class="shrink-0 rounded border border-stone-200 px-3 py-2 text-sm font-medium text-stone-600 transition-colors hover:bg-stone-50 disabled:opacity-40 dark:border-stone-800 dark:text-stone-400 dark:hover:bg-stone-900"
+				>
+					{suggesting ? 'Thinking…' : 'Suggest'}
+				</button>
+			</div>
+
+			{#if suggestions.length > 0}
+				<div class="flex flex-wrap gap-2">
+					{#each suggestions as suggestion}
+						<button
+							on:click={() => (inputText = suggestion)}
+							class="rounded-full border border-stone-200 px-3 py-1 text-xs text-stone-600 transition-colors hover:border-stone-400 hover:text-stone-800 dark:border-stone-700 dark:text-stone-400 dark:hover:border-stone-500 dark:hover:text-stone-200"
+						>
+							{suggestion}
+						</button>
+					{/each}
+				</div>
+			{/if}
+
+			<div class="flex gap-2">
+				<button
+					on:click={saveStatus}
+					disabled={saving || !inputText.trim()}
+					class="rounded bg-stone-800 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-stone-700 disabled:opacity-40 dark:bg-stone-200 dark:text-stone-900 dark:hover:bg-stone-300"
+				>
+					{saving ? 'Saving…' : 'Save'}
+				</button>
+				{#if currentStatus}
+					<button
+						on:click={clearStatus}
+						disabled={saving}
+						class="rounded border border-stone-200 px-4 py-2 text-sm text-stone-500 transition-colors hover:bg-stone-50 disabled:opacity-40 dark:border-stone-800 dark:hover:bg-stone-900"
+					>
+						Clear
+					</button>
+				{/if}
+			</div>
 		</div>
 
 		<div

--- a/src/routes/api/admin/status/+server.ts
+++ b/src/routes/api/admin/status/+server.ts
@@ -1,0 +1,14 @@
+import { getStatus, setStatus } from '$lib/server/status-config';
+import { json, type RequestHandler } from '@sveltejs/kit';
+
+export const GET: RequestHandler = async () => {
+	const status = await getStatus();
+	return json({ text: status?.text ?? null, updatedAt: status?.updatedAt ?? null });
+};
+
+export const POST: RequestHandler = async ({ request }) => {
+	const { text } = await request.json();
+	await setStatus(typeof text === 'string' ? text : '');
+	const status = await getStatus();
+	return json({ text: status?.text ?? null, updatedAt: status?.updatedAt ?? null });
+};

--- a/src/routes/api/admin/status/suggest/+server.ts
+++ b/src/routes/api/admin/status/suggest/+server.ts
@@ -1,0 +1,39 @@
+import { env } from '$env/dynamic/private';
+import { createOpenAI } from '@ai-sdk/openai';
+import { generateObject } from 'ai';
+import { z } from 'zod';
+import { json, type RequestHandler } from '@sveltejs/kit';
+
+const suggestionsSchema = z.object({
+	suggestions: z
+		.array(z.string())
+		.length(3)
+		.describe('Three short, playful status suggestions')
+});
+
+export const POST: RequestHandler = async ({ request }) => {
+	const { input } = await request.json();
+	if (!input || typeof input !== 'string') {
+		return json({ suggestions: [] }, { status: 400 });
+	}
+
+	const openai = createOpenAI({ apiKey: env.OPENAI_API_KEY });
+
+	const { object } = await generateObject({
+		model: openai('gpt-4o-mini'),
+		schema: suggestionsSchema,
+		prompt: `Generate 3 short, playful, lowercase status texts for a product designer's personal portfolio website. The designer wants to share what they're currently up to.
+
+Input from the designer: "${input}"
+
+Rules:
+- Each status should be under 50 characters
+- Use lowercase only, no period at the end
+- Be creative and fun — think casual, witty, human
+- Format like "currently [doing something fun] in [place]" or similar casual vibes
+- Vary the structure across the 3 options — don't start all with "currently"
+- Reference the specific activity/location from the input but make it more colorful`
+	});
+
+	return json({ suggestions: object.suggestions });
+};

--- a/src/routes/api/status/+server.ts
+++ b/src/routes/api/status/+server.ts
@@ -1,0 +1,7 @@
+import { getStatus } from '$lib/server/status-config';
+import { json, type RequestHandler } from '@sveltejs/kit';
+
+export const GET: RequestHandler = async () => {
+	const status = await getStatus();
+	return json({ text: status?.text ?? null, updatedAt: status?.updatedAt ?? null });
+};


### PR DESCRIPTION
Adds a fun eyebrow text on the landing page showing Hunter's current
status (e.g. "currently sampling birria in cdmx"). Status is stored
in Qdrant as a config payload, editable via the admin portal with
AI-powered suggestions from GPT-4o-mini.

https://claude.ai/code/session_01VKjCdaTgg9ecvNp7cttkHB