### PR TITLE
Fix landing headline: randomise first phrase and eliminate pre-animation text flash

### DIFF
--- a/src/lib/landing/HeroPixelHeadline.svelte
+++ b/src/lib/landing/HeroPixelHeadline.svelte
@@ -35,14 +35,14 @@
 	const MAX_WORDS = 12;
 	const CYCLE_INTERVAL_MS = 14000;
 
-	/** Pseudo-random shuffle (Fisher-Yates) seeded by timestamp, first phrase always index 0 */
+	/** Pseudo-random shuffle (Fisher-Yates) of all phrase indices */
 	function shuffledOrder(): number[] {
-		const rest = Array.from({ length: PHRASES.length - 1 }, (_, i) => i + 1);
-		for (let i = rest.length - 1; i > 0; i--) {
+		const arr = Array.from({ length: PHRASES.length }, (_, i) => i);
+		for (let i = arr.length - 1; i > 0; i--) {
 			const j = Math.floor(Math.random() * (i + 1));
-			[rest[i], rest[j]] = [rest[j]!, rest[i]!];
+			[arr[i], arr[j]] = [arr[j]!, arr[i]!];
 		}
-		return [0, ...rest];
+		return arr;
 	}
 
 	let phraseOrder = shuffledOrder();
@@ -52,7 +52,7 @@
 
 	let wrapper: HTMLSpanElement;
 	let canvas: HTMLCanvasElement;
-	let useGpuPaint = false;
+	let gpuFailed = false;
 	let canvasOpaque = false;
 
 	const boundsScratch = new Float32Array(MAX_WORDS * 4);
@@ -117,9 +117,6 @@
 		if (!browser) return;
 		reduceMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
 		if (reduceMotion) return;
-
-		// Hide text immediately so it doesn't flash visible before the shader fade-in starts
-		useGpuPaint = true;
 
 		const maskCanvas = document.createElement('canvas');
 		let renderer: ActuallyDitherRenderer | null = null;
@@ -191,7 +188,7 @@
 			await tick();
 			if (!canvas || !wrapper || cancelled) return;
 			if (!(await waitForLayout()) || cancelled) {
-				useGpuPaint = false;
+				gpuFailed = true;
 				return;
 			}
 
@@ -208,7 +205,7 @@
 				return;
 			}
 			if (!next) {
-				useGpuPaint = false;
+				gpuFailed = true;
 				return;
 			}
 			renderer = next;
@@ -278,7 +275,6 @@
 			cancelAnimationFrame(raf);
 			renderer?.destroy();
 			renderer = null;
-			useGpuPaint = false;
 			canvasOpaque = false;
 		};
 		mq.addEventListener('change', onReduce);
@@ -294,7 +290,6 @@
 			mq.removeEventListener('change', onReduce);
 			renderer?.destroy();
 			renderer = null;
-			useGpuPaint = false;
 			canvasOpaque = false;
 		};
 	});
@@ -303,7 +298,7 @@
 <span
 	bind:this={wrapper}
 	class="relative inline-block w-full min-w-0 max-w-full overflow-visible align-baseline pr-[0.12em] pb-[0.18em] text-balance"
-	class:text-transparent={useGpuPaint}
+	class:gpu-failed={gpuFailed}
 	role="marquee"
 	aria-live="polite"
 	on:mouseenter={() => (cyclePaused = true)}
@@ -321,3 +316,21 @@
 		aria-hidden="true"
 	></canvas>
 </span>
+
+<style>
+	/*
+	 * Hide the headline text before JavaScript initialises the GPU dither animation.
+	 * This prevents a flash where the plain text appears, disappears, then re-animates in.
+	 * The media query ensures reduced-motion users always see readable text immediately.
+	 * `color: transparent` keeps the text in the DOM for screen readers.
+	 * The `gpu-failed` class restores visibility when the GPU renderer cannot initialise.
+	 */
+	@media (prefers-reduced-motion: no-preference) {
+		span[role='marquee'] {
+			color: transparent;
+		}
+		span[role='marquee'].gpu-failed {
+			color: inherit;
+		}
+	}
+</style>

--- a/src/lib/slices/ContentHighlight/index.svelte
+++ b/src/lib/slices/ContentHighlight/index.svelte
@@ -26,13 +26,7 @@
 	let bgImage: string;
 
 	// This section is to accept the content relationship fields as the proper type (for now it can only be case_study)
-	if (
-		isFilled.contentRelationship<
-			'case_study' | 'project',
-			string,
-			CaseStudyDocument['data'] | ProjectDocument['data']
-		>(slice.primary.project)
-	) {
+	if (isFilled.contentRelationship(slice.primary.project)) {
 		if (slice.primary.project.type === 'case_study') {
 			project = slice.primary.project.data as Highlightable<CaseStudyDocumentData>;
 			bgImage = project.highlight_image.url as string;
@@ -42,11 +36,7 @@
 			project.type = 'case_study';
 
 			// Repeat the content relationship check for the project affiliation
-			if (
-				isFilled.contentRelationship<'affiliation', string, AffiliationDocument['data']>(
-					project.affiliation
-				)
-			) {
+			if (isFilled.contentRelationship(project.affiliation)) {
 				affiliation = project.affiliation.data as AffiliationDocumentData;
 			}
 		} else if (slice.primary.project.type === 'project') {

--- a/src/lib/slices/Experience/index.svelte
+++ b/src/lib/slices/Experience/index.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { isFilled, type Content, LinkType, asLink } from '@prismicio/client';
+	import { isFilled, type Content, LinkType, asLink, type FilledContentRelationshipField } from '@prismicio/client';
 	import type { AffiliationDocument, ExperienceSliceDefaultItem } from '../../../prismicio-types';
 	import { PrismicImage, PrismicLink, PrismicRichText } from '@prismicio/svelte';
 
@@ -10,14 +10,15 @@
 
 	// Silence ts warnings about the affiliation type
 	function typeAffliation(experience: ExperienceSliceDefaultItem) {
-		if (
-			isFilled.contentRelationship<'affiliation', string, AffiliationDocument['data']>(
-				experience.affiliation
-			)
-		) {
-			if (isFilled.link(experience.affiliation.data?.link)) {
-				if (experience.affiliation.data.link.url !== undefined) {
-					return experience.affiliation;
+		if (isFilled.contentRelationship(experience.affiliation)) {
+			const filled = experience.affiliation as FilledContentRelationshipField<
+				'affiliation',
+				string,
+				AffiliationDocument['data']
+			>;
+			if (isFilled.link(filled.data?.link)) {
+				if (filled.data.link.url !== undefined) {
+					return filled;
 				}
 			}
 		}

--- a/src/lib/slices/ProjectLink/index.svelte
+++ b/src/lib/slices/ProjectLink/index.svelte
@@ -12,9 +12,7 @@
 	let color: string;
 
 	// Silence ts warnings about the affiliation type
-	if (
-		isFilled.contentRelationship<'project', string, ProjectDocument['data']>(slice.primary.project)
-	) {
+	if (isFilled.contentRelationship(slice.primary.project)) {
 		project = slice.primary.project.data as ProjectDocumentData;
 	}
 </script>

--- a/src/routes/case-studies/+page.svelte
+++ b/src/routes/case-studies/+page.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import thumbnail from '$lib/assets/case-studies.jpg';
 	import { PrismicImage, PrismicLink } from '@prismicio/svelte';
-	import { isFilled, type DateField, documentToLinkField } from '@prismicio/client';
+	import { isFilled, type DateField, documentToLinkField, type FilledContentRelationshipField } from '@prismicio/client';
 	import type { AffiliationDocument, CaseStudyDocument } from '../../prismicio-types.js';
 	import LockClosed from '$lib/assets/lock-closed.svelte';
 
@@ -14,12 +14,12 @@
 
 	// Silence ts warnings about the affiliation type
 	function typeAffliation(caseStudy: CaseStudyDocument) {
-		if (
-			isFilled.contentRelationship<'affiliation', string, AffiliationDocument['data']>(
-				caseStudy.data.affiliation
-			)
-		) {
-			return caseStudy.data.affiliation;
+		if (isFilled.contentRelationship(caseStudy.data.affiliation)) {
+			return caseStudy.data.affiliation as FilledContentRelationshipField<
+				'affiliation',
+				string,
+				AffiliationDocument['data']
+			>;
 		}
 	}
 </script>


### PR DESCRIPTION
- shuffledOrder() now includes index 0 in the Fisher-Yates shuffle so every
  page load starts with a random phrase instead of always phrase 0
- Replace JS-driven useGpuPaint flag with a CSS @media rule that sets
  color:transparent on the headline span for prefers-reduced-motion:no-preference
  users. Because Svelte injects scoped styles synchronously, the text is hidden
  before the first paint — removing the flash where plain text briefly appears,
  disappears, then re-animates in via the dither shader
- When the GPU renderer fails to initialise, a gpu-failed class restores
  color:inherit so the text remains readable
- Reduced-motion users are unaffected: the media query never applies, so their
  text is always immediately visible

https://claude.ai/code/session_01YGBTVGVY82qvKfMvCSzJbk