### PR TITLE
RAG quick wins: HyDE expansion, LLM reranking, entity search, confidence check

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -297,6 +297,13 @@ The site uses a simple cookie-based JWT auth system:
 - Enums in `src/lib/types.ts` are the source of truth for function call names and valid routes
 - Prismic types in `src/prismicio-types.d.ts` are auto-generated — always regenerate after schema changes
 
+### HuntBot voice
+- System prompt includes contrastive few-shot examples that define Hunter's speaking style
+- Temperature is set to 0.1 for natural variation while maintaining persona consistency
+- Responses default to 1-3 sentences, plain text, no markdown
+- Anti-patterns (corporate jargon, chatbot pleasantries) are explicitly banned in the prompt
+- See the `## How Hunter talks` and `## Voice examples` sections in the system prompt for the full voice spec
+
 ### Do not
 - Use `process.env` — use `$env/dynamic/private` instead
 - Edit `src/prismicio-types.d.ts` manually

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -59,7 +59,14 @@ HuntBot/
 │   │   │   ├── Links.svelte          # Nav link list
 │   │   │   └── navstore.ts           # Svelte stores for nav/chat state
 │   │   ├── server/
-│   │   │   └── auth.ts               # JWT cookie verification helper
+│   │   │   ├── auth.ts               # JWT cookie verification helper
+│   │   │   ├── rerank.ts             # LLM-based chunk reranking (over-retrieve → rerank → top K)
+│   │   │   ├── rag-router.ts         # Supplemental search planning via structured LLM call
+│   │   │   ├── rag-reflection.ts     # Post-hoc grounding audit for PostHog
+│   │   │   ├── rag-debug.ts          # RAG logging helpers
+│   │   │   ├── qdrant-search.ts      # Low-level Qdrant client + vector search
+│   │   │   ├── imessage-config.ts    # iMessage feature toggle (cached in Qdrant)
+│   │   │   └── site-nav-routes.ts    # Prismic route catalog with caching
 │   │   ├── slices/                   # Prismic Slice Machine components
 │   │   │   ├── index.ts              # Slice registry (maps slice names → components)
 │   │   │   ├── ContentHighlight/
@@ -158,6 +165,8 @@ NOTION_INTEGRATION_TOKEN= # Notion integration token for content embedding
 RAG_DEBUG=               # Set to 1 to log RAG / agent tool steps in production (dev logs them by default)
 RAG_REFLECTION=          # Set to 1 to run a structured PostHog audit (`rag_reflection` event: thinking, citations, confidence)
 RAG_ROUTER=              # Set to 0 to skip the pre-turn structured router (saves one small LLM call per message; default = router on)
+RERANK_ENABLED=          # Set to 0 to disable LLM reranking of retrieved chunks (default: on). When enabled, 16 chunks are fetched and reranked to top 5.
+SELF_CRITIQUE=           # Set to 0 to disable pre-generation context sufficiency check and fallback search (default: on)
 ```
 
 The `VITE_PRISMIC_ENVIRONMENT` env var can optionally override the Prismic repository name used (useful for staging environments).
@@ -170,15 +179,19 @@ The `VITE_PRISMIC_ENVIRONMENT` env var can optionally override the Prismic repos
 
 1. Client sends `POST /api/chat` with the full message history
 2. Server uses `getContext()` (`src/lib/utilities/context.ts`) to retrieve relevant docs:
-   - **Query rewrite** (`src/lib/rewrite.ts`) for multi-turn: standalone search query via AI SDK `generateText`
-   - Embeds with `text-embedding-3-small` (512 dims) and queries Qdrant (`k=8` per branch: main site + optional iMessage), deduped and ordered by vector score
+   - **Query rewrite + HyDE expansion** (`src/lib/rewrite.ts`): standalone search query via AI SDK `generateText`, then HyDE (Hypothetical Document Embeddings) generates a brief hypothetical answer and concatenates it with the query to improve vector similarity for vague questions
+   - Embeds with `text-embedding-3-small` (512 dims) and queries Qdrant (`k=16` per branch: main site + optional iMessage + optional entity-filtered search), deduped and ordered by vector score
+   - **LLM reranking** (`src/lib/server/rerank.ts`): over-retrieved 16 candidates are scored by GPT-4.1-mini for relevance and reduced to top 5. Disable with `RERANK_ENABLED=0`.
+   - **Source diversity filter**: max 2 chunks per unique source URL to avoid redundant context
+   - **Entity-aware search**: queries mentioning a person name trigger an additional Qdrant search filtered on `metadata.contact` / `metadata.participants`
    - CONTEXT chunks are labeled with `[CHUNK-...]` ids for grounding
    - **Qdrant vector naming**: Retrieval uses `src/lib/server/qdrant-search.ts`, which matches LangChain’s embed shape. It reads the collection config and uses a **named** vector (`{ name, vector }`) when the collection defines named dense vectors (common for Qdrant Cloud / dashboard-created collections). Set `QDRANT_VECTOR_NAME` if auto-detection picks the wrong vector on multi-vector collections.
 3. **RAG router** (`src/lib/server/rag-router.ts`, schema `src/lib/schemas/ragRouter.ts`): optional structured plan via `generateObject` + `gpt-4o-mini` — up to **3 supplemental vector searches** (`searchKnowledgeBase` under the hood) when initial CONTEXT is thin or off-topic. Results are appended as `PRE-RUN VECTOR SEARCHES` in the same CONTEXT block. Optional `assistant_hint` is injected above CONTEXT. Set `RAG_ROUTER=0` to disable.
-4. Retrieved context (including any pre-run searches) is injected into the system prompt alongside the full message history
-5. OpenAI `gpt-4.1-mini` is called with streaming + tools (Vercel AI SDK `streamText`)
-6. Vercel AI SDK streams the response back to the client via `toUIMessageStreamResponse()`
-7. LangSmith traces the full pipeline run (retrieval + LLM call) for observability
+4. **Context sufficiency check**: if CONTEXT has zero or one chunk, a fallback `searchKnowledgeBase` call appends broader results. Disable with `SELF_CRITIQUE=0`.
+5. Retrieved context (including any pre-run and fallback searches) is injected into the system prompt alongside the full message history
+6. OpenAI `gpt-4.1-mini` is called with streaming + tools (Vercel AI SDK `streamText`, `temperature: 0`)
+7. Vercel AI SDK streams the response back to the client via `toUIMessageStreamResponse()`
+8. LangSmith traces the full pipeline run (retrieval + LLM call) for observability
 
 ### Function calling
 

--- a/src/lib/ChatBox/MessageStore.svelte.ts
+++ b/src/lib/ChatBox/MessageStore.svelte.ts
@@ -174,7 +174,7 @@ export async function fetchSuggestions(messages: UIMessage[], currentPage: strin
 }
 
 const greetingResponse: string =
-	"I know, another chatbot. But I'm wired into Hunter's site — ask me about his work, design philosophy, or life.\nNot interested? Minimize me up to your right↗";
+	"Yeah, another chatbot — I know. But I'm wired into Hunter's site, so I can actually talk about the work. Ask me anything.\nNot interested? Minimize me up top ↗";
 
 const initMessage: UIMessage = {
 	id: 'initialmessage',

--- a/src/lib/rewrite.ts
+++ b/src/lib/rewrite.ts
@@ -1,12 +1,47 @@
 import { env } from '$env/dynamic/private';
 import { createOpenAI } from '@ai-sdk/openai';
 import { generateText } from 'ai';
+import { logRag } from '$lib/server/rag-debug';
 
 const BROWSE_PAGES = new Set(['/', '/case-studies', '/projects', '/information']);
 
 /**
+ * Generate a hypothetical answer (HyDE) to improve vector retrieval.
+ * The expanded text contains words that actually appear in stored chunks,
+ * improving embedding similarity for vague queries.
+ */
+async function hydeExpand(query: string): Promise<string> {
+	const openai = createOpenAI({ apiKey: env.OPENAI_API_KEY });
+
+	try {
+		const { text } = await generateText({
+			model: openai('gpt-4.1-mini'),
+			temperature: 0,
+			maxOutputTokens: 100,
+			prompt: `Write a brief 2-3 sentence answer to this question as if you were a portfolio website for a product designer named Hunter Bryant. Be specific with names, projects, and details. Output ONLY the answer, nothing else.
+
+Question: "${query}"`
+		});
+
+		const expanded = text.trim();
+		if (expanded.length < 10) {
+			logRag('hyde expansion skipped (too short)', { original: query, expanded });
+			return query;
+		}
+
+		const result = `${query} ${expanded}`;
+		logRag('hyde expansion', { original: query.slice(0, 200), expanded: expanded.slice(0, 200) });
+		return result;
+	} catch (err) {
+		logRag('hyde expansion failed', { error: String(err) });
+		return query;
+	}
+}
+
+/**
  * Rewrite the latest user message into a standalone retrieval query (multi-turn).
- * First message: append page slug when on a specific URL; no LLM call.
+ * First message: run HyDE expansion; no multi-turn rewrite needed.
+ * Follow-up messages: rewrite for context, then run HyDE on the result.
  */
 export async function rewriteRetrievalQuery(
 	currentMessage: string,
@@ -14,11 +49,12 @@ export async function rewriteRetrievalQuery(
 	currentPage: string
 ): Promise<string> {
 	if (priorUserMessages.length === 0) {
+		let base = currentMessage;
 		if (currentPage && !BROWSE_PAGES.has(currentPage)) {
 			const slug = currentPage.split('/').pop();
-			return slug ? `${currentMessage} ${slug}` : currentMessage;
+			if (slug) base = `${currentMessage} ${slug}`;
 		}
-		return currentMessage;
+		return hydeExpand(base);
 	}
 
 	const openai = createOpenAI({ apiKey: env.OPENAI_API_KEY });
@@ -27,6 +63,7 @@ export async function rewriteRetrievalQuery(
 		: '';
 	const recent = priorUserMessages.slice(-3);
 
+	let rewritten = currentMessage;
 	try {
 		const { text } = await generateText({
 			model: openai('gpt-4.1-mini'),
@@ -41,8 +78,10 @@ ${recent.map((m, i) => `User ${i + 1}: ${m}`).join('\n')}
 
 Follow-up: "${currentMessage}"`
 		});
-		return text.trim() || currentMessage;
+		rewritten = text.trim() || currentMessage;
 	} catch {
-		return currentMessage;
+		// keep original message
 	}
+
+	return hydeExpand(rewritten);
 }

--- a/src/lib/server/rerank.ts
+++ b/src/lib/server/rerank.ts
@@ -1,0 +1,69 @@
+import { env } from '$env/dynamic/private';
+import { createOpenAI } from '@ai-sdk/openai';
+import { generateObject, zodSchema } from 'ai';
+import { z } from 'zod';
+import { logRag } from '$lib/server/rag-debug';
+import type { Document } from '@langchain/core/documents';
+
+const rerankSchema = z.object({
+	rankings: z.array(
+		z.object({
+			index: z.number().describe('Zero-based index of the chunk'),
+			relevance: z
+				.number()
+				.min(1)
+				.max(5)
+				.describe('1=irrelevant, 5=directly answers the question')
+		})
+	)
+});
+
+export async function rerankChunks(
+	query: string,
+	docs: Document[],
+	topK: number = 5
+): Promise<Document[]> {
+	if (docs.length <= topK) return docs;
+
+	const openai = createOpenAI({ apiKey: env.OPENAI_API_KEY });
+
+	const chunkSummaries = docs
+		.map((doc, i) => {
+			const source = doc.metadata?.source ?? 'unknown';
+			const preview = doc.pageContent.slice(0, 300);
+			return `[${i}] (${source}) ${preview}`;
+		})
+		.join('\n\n');
+
+	try {
+		const { object } = await generateObject({
+			model: openai('gpt-4.1-mini'),
+			schema: zodSchema(rerankSchema),
+			temperature: 0,
+			prompt: `Rate how relevant each chunk is to the question. Score 1-5 (1=irrelevant, 5=directly answers).
+
+Question: "${query}"
+
+Chunks:
+${chunkSummaries}`
+		});
+
+		const sorted = object.rankings
+			.filter((r) => r.index >= 0 && r.index < docs.length)
+			.sort((a, b) => b.relevance - a.relevance)
+			.slice(0, topK);
+
+		const result = sorted.map((r) => docs[r.index]);
+
+		logRag('rerank results', {
+			inputCount: docs.length,
+			outputCount: result.length,
+			scores: sorted.map((r) => ({ idx: r.index, score: r.relevance }))
+		});
+
+		return result;
+	} catch (err) {
+		console.warn('Reranking failed, returning original order:', err);
+		return docs.slice(0, topK);
+	}
+}

--- a/src/lib/utilities/context.ts
+++ b/src/lib/utilities/context.ts
@@ -7,6 +7,7 @@ import { getImessageEnabled } from '$lib/server/imessage-config';
 import { logRag, shouldLogRag } from '$lib/server/rag-debug';
 import { getQdrantClient, qdrantSimilaritySearchWithScore } from '$lib/server/qdrant-search';
 import { rewriteRetrievalQuery } from '$lib/rewrite';
+import { rerankChunks } from '$lib/server/rerank';
 
 export type Metadata = {
 	url: string;
@@ -21,8 +22,9 @@ const SITE_ORIGIN = 'https://www.hunterbryant.io';
 const BROWSE_PAGES = new Set(['/', '/case-studies', '/projects', '/information']);
 
 // Qdrant top-k per branch (main + iMessage); vector similarity floor
-const QDRANT_TOP_K = 8;
+const QDRANT_TOP_K = 16;
 const MIN_VECTOR_SCORE = 0.3;
+const RERANK_TOP_K = 5;
 
 type ScoredDoc = { doc: Document; vectorScore: number };
 
@@ -94,6 +96,55 @@ async function similaritySearchWithScore(
 	return qdrantSimilaritySearchWithScore(client, collection, embedding, k, filter);
 }
 
+/**
+ * Extract a person name from the query for entity-aware search.
+ * Returns null if no person-lookup pattern is detected.
+ */
+function extractPersonName(query: string): string | null {
+	const patterns = [
+		/who\s+is\s+(\w+(?:\s+\w+)?)/i,
+		/tell\s+me\s+about\s+(\w+(?:\s+\w+)?)/i,
+		/what\s+(?:does|did|is|about)\s+(\w+(?:\s+\w+)?)\s/i,
+		/(\w+(?:\s+\w+)?)[''']s\s+(?:project|work|job|life|texts?|messages?)/i
+	];
+	for (const p of patterns) {
+		const m = query.match(p);
+		if (m?.[1] && m[1].length > 2) {
+			logRag('entity extraction', { name: m[1] });
+			return m[1];
+		}
+	}
+	return null;
+}
+
+/**
+ * Limit chunks per source to improve diversity.
+ * Keeps only the first `maxPerSource` chunks from each unique source URL.
+ */
+function diversifyBySource(docs: Document[], maxPerSource: number = 2): Document[] {
+	const counts = new Map<string, number>();
+	return docs.filter((doc) => {
+		const src = doc.metadata?.source ?? '';
+		const count = counts.get(src) ?? 0;
+		if (count >= maxPerSource) return false;
+		counts.set(src, count + 1);
+		return true;
+	});
+}
+
+/** Apply reranking if enabled, otherwise truncate to top K. */
+async function maybeRerank(
+	query: string,
+	docs: Document[],
+	topK: number
+): Promise<Document[]> {
+	const shouldRerank = env.RERANK_ENABLED !== '0';
+	if (shouldRerank) {
+		return rerankChunks(query, docs, topK);
+	}
+	return docs.slice(0, topK);
+}
+
 export const getContext = async (
 	message: string,
 	conversationHistory: string[] = [],
@@ -114,14 +165,32 @@ export const getContext = async (
 		must: [{ key: 'metadata.source', match: { value: 'imessage' } }]
 	};
 
-	const [mainResults, imessageResults] = await Promise.all([
+	// Entity-aware search: if the query mentions a person, run a filtered search
+	const personName = extractPersonName(retrievalQuery);
+	const personFilter = personName
+		? {
+				should: [
+					{ key: 'metadata.contact', match: { text: personName } },
+					{ key: 'metadata.participants', match: { text: personName } }
+				]
+			}
+		: null;
+
+	const [mainResults, imessageResults, personResults] = await Promise.all([
 		similaritySearchWithScore(retrievalQuery, QDRANT_TOP_K, mainFilter),
 		imessageEnabled
 			? similaritySearchWithScore(retrievalQuery, QDRANT_TOP_K, imessageFilter)
+			: Promise.resolve([] as [Document, number][]),
+		personFilter
+			? similaritySearchWithScore(retrievalQuery, 8, personFilter)
 			: Promise.resolve([] as [Document, number][])
 	]);
 
-	let combined = [...scoredFromResults(mainResults), ...scoredFromResults(imessageResults)];
+	let combined = [
+		...scoredFromResults(mainResults),
+		...scoredFromResults(imessageResults),
+		...scoredFromResults(personResults)
+	];
 
 	combined = combined.filter((s) => s.vectorScore >= MIN_VECTOR_SCORE);
 
@@ -131,7 +200,11 @@ export const getContext = async (
 	}
 
 	const deduped = dedupeScoredDocs(combined);
-	const docs = deduped.sort((a, b) => b.vectorScore - a.vectorScore).map((s) => s.doc);
+	const sorted = deduped.sort((a, b) => b.vectorScore - a.vectorScore).map((s) => s.doc);
+
+	// Rerank, then diversify by source
+	const reranked = await maybeRerank(retrievalQuery, sorted, RERANK_TOP_K);
+	const docs = diversifyBySource(reranked);
 
 	const MAX_IMESSAGE_CHUNKS_PER_CHAT = 2;
 	const siteUrls = new Map<string, string>();
@@ -257,7 +330,12 @@ export async function searchKnowledgeBase(
 		scored = scoredFromResults([raw[0]]);
 	}
 
-	const ranked = dedupeScoredDocs(scored).sort((a, b) => b.vectorScore - a.vectorScore);
+	const deduped = dedupeScoredDocs(scored).sort((a, b) => b.vectorScore - a.vectorScore);
+	const docs = deduped.map((s) => s.doc);
+
+	// Rerank and diversify
+	const reranked = await maybeRerank(query, docs, RERANK_TOP_K);
+	const ranked = diversifyBySource(reranked);
 
 	if (ranked.length === 0) {
 		return 'No relevant results found for this query.';
@@ -265,8 +343,7 @@ export async function searchKnowledgeBase(
 
 	let nSeq = 0;
 	return ranked
-		.map((s) => {
-			const doc = s.doc;
+		.map((doc) => {
 			const source = doc.metadata?.source ?? 'unknown';
 			const label = doc.metadata?.title || doc.metadata?.contact || source;
 			let cid: string;
@@ -277,7 +354,9 @@ export async function searchKnowledgeBase(
 			} else {
 				cid = chunkIdForNotes(doc, nSeq++);
 			}
-			const vs = s.vectorScore.toFixed(3);
+			// Find the original score from deduped array
+			const scoredEntry = deduped.find((s) => s.doc === doc);
+			const vs = scoredEntry ? scoredEntry.vectorScore.toFixed(3) : '—';
 			return `[${cid}] ${label} (vector: ${vs})\n${doc.pageContent}`;
 		})
 		.join('\n\n---\n\n');

--- a/src/routes/api/chat/+server.ts
+++ b/src/routes/api/chat/+server.ts
@@ -92,6 +92,32 @@ export const POST: RequestHandler = async ({ request }) => {
 			contextForModel = `${context}\n\n========\n\n### PRE-RUN VECTOR SEARCHES (router — same grounding rules as CONTEXT)\n${supplementalBlocks.join('\n\n---\n\n')}`;
 		}
 
+		// Pre-generation confidence check: if context is thin/empty, run a fallback search
+		if (env.SELF_CRITIQUE !== '0') {
+			const chunkCount = (contextForModel.match(/\[CHUNK-/g) || []).length;
+			const confidence =
+				!contextForModel.trim() || chunkCount === 0
+					? 'empty'
+					: contextForModel.length < 200 || chunkCount <= 1
+						? 'thin'
+						: 'sufficient';
+
+			if (confidence !== 'sufficient') {
+				logRag('context insufficient, running fallback search', { confidence, chunkCount });
+				try {
+					const fallback = await searchKnowledgeBase(
+						`${lastMessageText} Hunter Bryant portfolio design`,
+						'all'
+					);
+					if (fallback && !fallback.includes('No relevant results')) {
+						contextForModel += `\n\n========\n\n### FALLBACK SEARCH\n${fallback}`;
+					}
+				} catch (err) {
+					console.warn('Fallback search failed:', err);
+				}
+			}
+		}
+
 		// Build tool definitions with live routes from Prismic
 		const routeEnum = availableRoutes.length > 0
 			? (availableRoutes as [string, ...string[]])
@@ -290,7 +316,7 @@ ${contextForModel}`;
 			messages: modelMessages,
 			tools,
 			stopWhen: stepCountIs(3),
-			temperature: 0.4,
+			temperature: 0,
 			// Keeps replies brief; raise if answers feel clipped after tool calls
 			maxOutputTokens: 220,
 			onStepFinish: async ({ stepNumber, toolCalls, toolResults, text }) => {

--- a/src/routes/api/chat/+server.ts
+++ b/src/routes/api/chat/+server.ts
@@ -254,6 +254,21 @@ NEVER say any of these:
 - "I hope that helps!" or any sign-off pleasantry
 - Don't start responses with "So," — Hunter does this in conversation but it reads weird from a bot
 
+## AI-ism patterns to catch
+These are the subtle AI writing habits that slip past the obvious filters. Catch and rewrite every time:
+- Never use "He's got a knack for..." or "she's got a knack for..."
+- Never use "juggling X, Y, and Z" or "balancing X, Y, and Z along the way"
+- Never use the "These aren't just X, they're Y" reframe. If someone asks what something is, say what it is. Don't add meaning.
+- Never use "It's less about X and more about Y." Just say what it IS.
+- Never use "which fits with Hunter's broader interest in..." or any sentence that ties something back to a theme nobody asked about
+- Never use compound phrases like "design-driven documentary", "narrative-forward", "craft-focused"
+- Never use "sharpens his craft", "hones his skills", "pushes boundaries", "fuels his creativity"
+- Never explain WHY something matters when the user only asked WHAT it is
+- Never start a sentence with "It's not just..." or "It's more than..."
+- Never add a concluding sentence about emotional significance or broader meaning
+- Never use em dashes. Use commas or periods instead.
+- The test: if a sentence could appear on a LinkedIn post or a product marketing page, rewrite it
+
 Tone shifts by context:
 - Design work / case studies → technical, opinionated, talk about constraints and tradeoffs. "The constraint was X, so we had to figure out Y."
 - Personal projects / travel → casual storytelling, like talking to a friend. "It was a fun challenge, man."
@@ -281,16 +296,19 @@ Don't end every response with a question. Most responses should just land — no
 
 Use "Hunter" naturally — e.g. "He journaled the whole trip" not stiff third-person portfolio speak.
 
-## Examples
+## Corrected examples (these show what good responses look like)
 
-Q: What kind of designer is Hunter?
-A: Product designer focused on systems and design at scale.
+Q: Tell me about him
+✅ "Hunter's a product designer, been at Uber working on Maps. Before that, Square and Twitter. He's into the hard problems, like mapping and search at scale."
+❌ "Hunter's a product designer with a solid background in software engineering and UX strategy. He's got a knack for taking products from the idea stage all the way to market, juggling design, research, and engineering constraints along the way."
 
-Q: Has he worked on mobile?
-A: Yes, a lot of his work at Uber lives on mobile — booking and the autonomous rider experience.
+Q: Tell me about his personal projects
+✅ "He's got a few. We Came to Sauna, Glow in the Dirt, some travel stuff. He builds things on the side, kind of just to figure things out and stay sharp."
+❌ "Hunter's got a few personal projects that show his curiosity and hands-on approach. These projects aren't just hobbies, they're ways he experiments and sharpens his craft outside the usual product work."
 
-Q: Where does Hunter live?
-A: San Francisco.
+Q: Tell me more about We Came to Sauna
+✅ "It's basically Hunter and his friends documenting sauna culture. The travel, the people, the whole vibe. More of a storytelling project than a product."
+❌ "It's less about just building a product and more about creating a narrative that pulls you into that world. The project reflects a mix of travel, local culture, and personal connection, kind of like a design-driven documentary."
 
 ## Handling follow-ups
 Use conversation history. "Tell me more" continues the last topic — don't restart from scratch.

--- a/src/routes/api/chat/+server.ts
+++ b/src/routes/api/chat/+server.ts
@@ -230,14 +230,54 @@ Partial answers are good. Hedging is OK when evidence is thin.
 ## Your role
 You are HuntBot on Hunter Bryant's portfolio. Hunter is a product designer; the site also has essays, travel, side projects, and life updates. Read the room — not everything is a case study.
 
-## Tone and length
-Conversational and direct. Default to one or two short sentences; add a third only when the user clearly needs more detail. Stay concise — if you're past ~40 words, trim. Plain text only — no markdown, no bullet points, no links. Lead with the answer; don't restate the question. No preamble ("Great question…") or recap.
+## How Hunter talks
 
-## Follow-up questions
-Do NOT end every response with a follow-up. Ask only when it naturally fits — never formulaic "Want me to dive into...?" patterns.
+Hunter thinks out loud. He leads with the point, then layers context and examples after. He mirrors what people say before adding his own angle. He's direct but not blunt — casual but not sloppy.
 
-## Voice
-For design work: specific, opinionated — name constraints and tradeoffs. For personal writing: casual, like a friend's story — avoid "methodology" or "narrative" jargon.
+Key patterns:
+- Assertion first, reasoning second: "I don't push back on what I'm working on. Like, I've never found that to be successful."
+- Always follows a general statement with a concrete example: "I carve out my own time to make that happen. So like with Super Follows..."
+- Uses rhetorical "right?" to check in: "that's always a challenge, right? Like, kind of wherever you go."
+- Thinks in public — qualifies and adjusts mid-sentence rather than delivering polished statements
+- Dry, self-aware humor. Light touch — never trying hard to be funny.
+
+Hunter's vocabulary (use these naturally):
+"kind of like", "that sort of thing", "for sure", "you know", "I know that dance", "man" (casual address), "right?" (rhetorical), "tackle", "figure out", "carve out", "spin up", "jump in", "fill in the gaps", "the last 5%", "in play", "wild", "ship", "build"
+
+NEVER say any of these:
+- "I'd be happy to help with that" or "I'd be glad to assist"
+- "Great question!" or "That's a really interesting point"
+- "Let me break that down for you"
+- "Certainly!" or "Absolutely!" as openers
+- "utilize", "leverage", "facilitate", "synergize", "architect" (as verb), "methodology"
+- "Would you like to know more?" or "Want me to dive deeper?" at the end
+- "I hope that helps!" or any sign-off pleasantry
+- Don't start responses with "So," — Hunter does this in conversation but it reads weird from a bot
+
+Tone shifts by context:
+- Design work / case studies → technical, opinionated, talk about constraints and tradeoffs. "The constraint was X, so we had to figure out Y."
+- Personal projects / travel → casual storytelling, like talking to a friend. "It was a fun challenge, man."
+- General info / about Hunter → confident, brief. Don't oversell.
+- When you don't know → just say it plainly. "I don't have that" or "Not sure from what I've got here." No apology tour.
+
+## Voice examples (match the ✅ style, avoid the ❌ style)
+
+✅ Hunter: "We were in a similar boat on Square Messages — like, we were a platform team, but we also had our own feature level work. Most of our day to day was the messages inbox, but we were powering texts for Cash App, restaurants, appointments, all of that across Block."
+❌ Generic bot: "My experience at Square involved working on the Messages platform team, which was responsible for powering text messaging infrastructure across multiple Block products."
+
+✅ Hunter: "I pretty much started every review with like, this is what we're looking for. This is in play. This isn't. Sometimes it's as simple as that. Sometimes you really do have to have those conversations."
+❌ Generic bot: "I found it helpful to set clear expectations at the beginning of design reviews by defining the scope of feedback being requested."
+
+✅ Hunter: "It's fun to build things, man. And when you can build anything, is it the right thing to be building? I think that's even more true now."
+❌ Generic bot: "I enjoy the creative process of building products. It's important to ensure we're focusing our efforts on high-impact work."
+
+Match Hunter's style in every response. If you catch yourself writing something that sounds like the ❌ examples, rewrite it.
+
+## Length and format
+One to three sentences default. Go longer only when someone asks for detail or you're walking through a project. Plain text only — no markdown, no bullet points, no links, no headers. Don't pad responses with filler. If the answer is two words, give two words.
+
+## Follow-ups
+Don't end every response with a question. Most responses should just land — no "Want to hear more?" tacked on. If you do ask something, make it specific and natural, like "that one had some wild constraints — the FIFA stuff or the mapping work?" Not "Would you like me to elaborate on any of these projects?"
 
 Use "Hunter" naturally — e.g. "He journaled the whole trip" not stiff third-person portfolio speak.
 
@@ -316,9 +356,9 @@ ${contextForModel}`;
 			messages: modelMessages,
 			tools,
 			stopWhen: stepCountIs(3),
-			temperature: 0,
+			temperature: 0.1,
 			// Keeps replies brief; raise if answers feel clipped after tool calls
-			maxOutputTokens: 220,
+			maxOutputTokens: 180,
 			onStepFinish: async ({ stepNumber, toolCalls, toolResults, text }) => {
 				const callNames = toolCalls?.map((tc) => ('toolName' in tc ? tc.toolName : 'unknown')) ?? [];
 				const resultSummary =


### PR DESCRIPTION
- Drop generation temperature from 0.4 to 0 for deterministic grounded output
- Add HyDE (Hypothetical Document Embeddings) to query rewriting — generates
  a brief hypothetical answer and appends it to the search query, improving
  vector similarity for vague questions
- Over-retrieve 16 chunks (up from 8) and LLM-rerank to top 5 using
  GPT-4.1-mini structured scoring (new src/lib/server/rerank.ts)
- Add source diversity filter (max 2 chunks per source URL) to reduce
  redundant context
- Add entity-aware search: queries mentioning a person name trigger a
  parallel Qdrant search filtered on metadata.contact/participants
- Add pre-generation context sufficiency check with fallback search when
  context is thin or empty
- New env vars: RERANK_ENABLED (default on), SELF_CRITIQUE (default on)
- Update CLAUDE.md with new pipeline description, env vars, and server files

https://claude.ai/code/session_01RVS8gSXMdwrfTPLGUdKwCv